### PR TITLE
Gate temperature/top_p/top_k by model version (Opus 4.7+ deprecation)

### DIFF
--- a/api.go
+++ b/api.go
@@ -106,9 +106,12 @@ type SystemPrompt struct {
 // Messages is a sequence of messages in a conversation. It usually starts with
 // a user message, and alternates between user and assistant messages.
 type Messages struct {
-	Model       string           `json:"model"`
-	MaxTokens   int              `json:"max_tokens"`
-	Temperature float64          `json:"temperature"`
+	Model     string `json:"model"`
+	MaxTokens int    `json:"max_tokens"`
+	// Temperature is a pointer so the field can be omitted entirely from the
+	// JSON body — Claude Opus 4.7 and later reject any temperature key (the
+	// check is presence-based, not value-based). See supportsSampling.
+	Temperature *float64         `json:"temperature,omitempty"`
 	TopP        float64          `json:"top_p,omitempty"`
 	TopK        int              `json:"top_k,omitempty"`
 	System      interface{}      `json:"system,omitempty"` // Can be string or []SystemPrompt
@@ -379,19 +382,10 @@ func (c *Conversation) sendInternal(text string, sampling llmapi.Sampling) (*Res
 	// Note: The API doesn't support caching individual tools, only the entire tools array
 	// Tool caching is handled at the API level, not per-tool
 
-	// Use sampling overrides if provided (non-zero), otherwise use conversation defaults
-	temperature := c.Settings.Temperature
-	if sampling.Temperature != 0 {
-		temperature = sampling.Temperature
-	}
-	topP := c.Settings.TopP
-	if sampling.TopP != 0 {
-		topP = sampling.TopP
-	}
-	topK := c.Settings.TopK
-	if sampling.TopK != 0 {
-		topK = sampling.TopK
-	}
+	// Resolve sampling parameters, layering per-call overrides over conversation
+	// defaults and dropping them entirely on models that no longer accept them
+	// (Claude Opus 4.7+; see supportsSampling).
+	temperature, topP, topK := resolveSampling(c.Settings, sampling)
 
 	// Apply conversation turn cache breakpoints before building the request
 	c.applyCacheBreakpoints()
@@ -563,19 +557,8 @@ func (c *Conversation) SendRichStreaming(content []llmapi.ContentBlock, sampling
 		}
 	}
 
-	// Use sampling overrides if provided
-	temperature := c.Settings.Temperature
-	if sampling.Temperature != 0 {
-		temperature = sampling.Temperature
-	}
-	topP := c.Settings.TopP
-	if sampling.TopP != 0 {
-		topP = sampling.TopP
-	}
-	topK := c.Settings.TopK
-	if sampling.TopK != 0 {
-		topK = sampling.TopK
-	}
+	// Resolve sampling parameters, gated by model capability (Opus 4.7+ omits them).
+	temperature, topP, topK := resolveSampling(c.Settings, sampling)
 
 	// Apply conversation turn cache breakpoints before building the request
 	c.applyCacheBreakpoints()
@@ -881,19 +864,8 @@ func (conversation *Conversation) SendStreaming(text string, sampling llmapi.Sam
 		}
 	}
 
-	// Use sampling overrides if provided (non-zero), otherwise use conversation defaults
-	temperature := conversation.Settings.Temperature
-	if sampling.Temperature != 0 {
-		temperature = sampling.Temperature
-	}
-	topP := conversation.Settings.TopP
-	if sampling.TopP != 0 {
-		topP = sampling.TopP
-	}
-	topK := conversation.Settings.TopK
-	if sampling.TopK != 0 {
-		topK = sampling.TopK
-	}
+	// Resolve sampling parameters, gated by model capability (Opus 4.7+ omits them).
+	temperature, topP, topK := resolveSampling(conversation.Settings, sampling)
 
 	// Apply conversation turn cache breakpoints before building the request
 	conversation.applyCacheBreakpoints()

--- a/model_version.go
+++ b/model_version.go
@@ -1,0 +1,117 @@
+package anthropic
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/wbrown/llmapi"
+)
+
+// modelDateSuffix matches the 8-digit date suffix on older Anthropic model
+// IDs (e.g. "claude-3-5-sonnet-20241022"). The date does not contribute to
+// the version and is stripped before parsing.
+var modelDateSuffix = regexp.MustCompile(`-[0-9]{8}$`)
+
+// parseModelVersion extracts the (major, minor) version from an Anthropic
+// model ID. Returns ok=false if the string does not start with "claude-"
+// or contains no numeric version component.
+//
+// Recognized forms:
+//
+//	claude-opus-4-8           -> (4, 8)
+//	claude-sonnet-4-6         -> (4, 6)
+//	claude-haiku-4-5-20251001 -> (4, 5)
+//	claude-3-5-sonnet-...     -> (3, 5)
+//	claude-3-opus-...         -> (3, 0)   no minor present
+//	claude-2.1                -> (2, 1)
+//	claude-instant-1.2        -> (1, 2)
+//
+// When only a major component is present, minor is reported as 0.
+func parseModelVersion(model string) (major, minor int, ok bool) {
+	if !strings.HasPrefix(model, "claude-") {
+		return 0, 0, false
+	}
+	rest := strings.TrimPrefix(model, "claude-")
+	rest = modelDateSuffix.ReplaceAllString(rest, "")
+
+	// Split on both '-' and '.' so "claude-opus-4-8" and "claude-2.1"
+	// parse uniformly.
+	tokens := strings.FieldsFunc(rest, func(r rune) bool {
+		return r == '-' || r == '.'
+	})
+
+	var nums []int
+	for _, tok := range tokens {
+		n, err := strconv.Atoi(tok)
+		if err != nil {
+			continue
+		}
+		nums = append(nums, n)
+	}
+	if len(nums) == 0 {
+		return 0, 0, false
+	}
+	major = nums[0]
+	if len(nums) >= 2 {
+		minor = nums[1]
+	}
+	return major, minor, true
+}
+
+// supportsSampling reports whether the given model accepts the temperature,
+// top_p, and top_k sampling parameters.
+//
+// Anthropic deprecated all three on Claude Opus 4.7 and applies the same
+// constraint to Claude Opus 4.8; sending any of them — even at the documented
+// default value — returns HTTP 400 because the check is presence-based. The
+// cutoff is applied family-agnostically: any model at version 4.7 or newer
+// omits the sampling parameters.
+//
+// Unrecognized model IDs return false. Omitting the parameters is the safer
+// default against an unknown future model, since the failure mode for the
+// other direction is a hard 400 rather than a quality regression.
+//
+// See https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7
+func supportsSampling(model string) bool {
+	major, minor, ok := parseModelVersion(model)
+	if !ok {
+		return false
+	}
+	if major > 4 {
+		return false
+	}
+	if major == 4 && minor >= 7 {
+		return false
+	}
+	return true
+}
+
+// resolveSampling computes the effective sampling parameters for a request.
+// It layers per-call overrides over conversation defaults, then gates the
+// result by the target model's capabilities: when the model does not accept
+// sampling parameters, all three return values are zeroed so JSON marshalling
+// omits them from the request body (Temperature returns nil, TopP and TopK
+// rely on the existing omitempty tags).
+//
+// The non-zero override convention matches the original three-block pattern
+// at each call site: a zero value in llmapi.Sampling means "use the
+// conversation's configured value."
+func resolveSampling(settings *SampleSettings, override llmapi.Sampling) (temperature *float64, topP float64, topK int) {
+	if !supportsSampling(settings.Model) {
+		return nil, 0, 0
+	}
+	t := settings.Temperature
+	if override.Temperature != 0 {
+		t = override.Temperature
+	}
+	p := settings.TopP
+	if override.TopP != 0 {
+		p = override.TopP
+	}
+	k := settings.TopK
+	if override.TopK != 0 {
+		k = override.TopK
+	}
+	return &t, p, k
+}

--- a/model_version_test.go
+++ b/model_version_test.go
@@ -1,0 +1,231 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/wbrown/llmapi"
+)
+
+// TestParseModelVersion covers the recognized Anthropic model ID shapes plus
+// unrecognized inputs that should report ok=false.
+func TestParseModelVersion(t *testing.T) {
+	cases := []struct {
+		model     string
+		wantMajor int
+		wantMinor int
+		wantOK    bool
+	}{
+		// Current naming scheme: claude-<family>-<major>-<minor>
+		{"claude-opus-4-8", 4, 8, true},
+		{"claude-opus-4-7", 4, 7, true},
+		{"claude-opus-4-6", 4, 6, true},
+		{"claude-opus-4-5", 4, 5, true},
+		{"claude-opus-4-1", 4, 1, true},
+		{"claude-opus-4-0", 4, 0, true},
+		{"claude-sonnet-4-6", 4, 6, true},
+		{"claude-sonnet-4-5", 4, 5, true},
+		{"claude-haiku-4-5", 4, 5, true},
+
+		// With trailing date suffix
+		{"claude-haiku-4-5-20251001", 4, 5, true},
+		{"claude-3-5-sonnet-20241022", 3, 5, true},
+		{"claude-3-7-sonnet-20250219", 3, 7, true},
+		{"claude-3-5-haiku-20241022", 3, 5, true},
+
+		// Legacy naming with no minor component → minor reports as 0
+		{"claude-3-opus-20240229", 3, 0, true},
+		{"claude-3-sonnet-20240229", 3, 0, true},
+		{"claude-3-haiku-20240307", 3, 0, true},
+
+		// Dotted versions
+		{"claude-2.1", 2, 1, true},
+		{"claude-2.0", 2, 0, true},
+		{"claude-instant-1.2", 1, 2, true},
+
+		// Unrecognized — these should return ok=false so callers can apply a
+		// conservative default.
+		{"", 0, 0, false},
+		{"gpt-4", 0, 0, false},
+		{"claude", 0, 0, false}, // no leading "claude-"
+		{"claude-future-model-xyz", 0, 0, false},
+		{"claude-", 0, 0, false}, // empty after prefix
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			gotMajor, gotMinor, gotOK := parseModelVersion(tc.model)
+			if gotOK != tc.wantOK {
+				t.Fatalf("parseModelVersion(%q) ok=%v, want %v", tc.model, gotOK, tc.wantOK)
+			}
+			if !gotOK {
+				return
+			}
+			if gotMajor != tc.wantMajor || gotMinor != tc.wantMinor {
+				t.Errorf("parseModelVersion(%q) = (%d, %d), want (%d, %d)",
+					tc.model, gotMajor, gotMinor, tc.wantMajor, tc.wantMinor)
+			}
+		})
+	}
+}
+
+// TestSupportsSampling locks in the deprecation cutoff: models at version 4.7
+// or newer must report false (per the Opus 4.7/4.8 docs), and unrecognized
+// model IDs must also report false (conservative default — a 400 from a real
+// model is a worse failure than dropping a sampling param for an unknown one).
+func TestSupportsSampling(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		// Deprecated (>= 4.7)
+		{"claude-opus-4-8", false},
+		{"claude-opus-4-7", false},
+
+		// Hypothetical future bumps follow the same rule family-agnostically.
+		{"claude-sonnet-4-7", false},
+		{"claude-haiku-4-7", false},
+		{"claude-opus-5-0", false},
+
+		// Still supported (<= 4.6)
+		{"claude-opus-4-6", true},
+		{"claude-opus-4-5", true},
+		{"claude-opus-4-1", true},
+		{"claude-opus-4-0", true},
+		{"claude-sonnet-4-6", true},
+		{"claude-sonnet-4-5", true},
+		{"claude-haiku-4-5", true},
+		{"claude-haiku-4-5-20251001", true},
+		{"claude-3-7-sonnet-20250219", true},
+		{"claude-3-5-sonnet-20241022", true},
+		{"claude-3-opus-20240229", true},
+		{"claude-2.1", true},
+		{"claude-instant-1.2", true},
+
+		// Unrecognized → false (conservative)
+		{"", false},
+		{"gpt-4", false},
+		{"claude-future-model-xyz", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			if got := supportsSampling(tc.model); got != tc.want {
+				t.Errorf("supportsSampling(%q) = %v, want %v", tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveSampling_UnsupportedModelOmitsAll verifies that on an unsupported
+// model all three sampling params are zeroed (Temperature returns nil so the
+// pointer omits the field; TopP and TopK return 0 so omitempty drops them).
+func TestResolveSampling_UnsupportedModelOmitsAll(t *testing.T) {
+	settings := &SampleSettings{
+		Model:       "claude-opus-4-8",
+		Temperature: 0.7,
+		TopP:        0.9,
+		TopK:        40,
+	}
+	override := llmapi.Sampling{Temperature: 0.5, TopP: 0.8, TopK: 20}
+
+	temperature, topP, topK := resolveSampling(settings, override)
+
+	if temperature != nil {
+		t.Errorf("Temperature should be nil for opus-4-8, got %v", *temperature)
+	}
+	if topP != 0 {
+		t.Errorf("TopP should be 0 for opus-4-8, got %v", topP)
+	}
+	if topK != 0 {
+		t.Errorf("TopK should be 0 for opus-4-8, got %v", topK)
+	}
+}
+
+// TestResolveSampling_SupportedModelKeepsZeroTemperature verifies that on a
+// supported model an explicit Temperature=0 still produces a non-nil pointer.
+// This is the core reason Temperature must be *float64: float64+omitempty
+// would silently drop intentional deterministic sampling.
+func TestResolveSampling_SupportedModelKeepsZeroTemperature(t *testing.T) {
+	settings := &SampleSettings{
+		Model:       "claude-sonnet-4-6",
+		Temperature: 0.0,
+	}
+	temperature, _, _ := resolveSampling(settings, llmapi.Sampling{})
+
+	if temperature == nil {
+		t.Fatal("Temperature must be non-nil on supported model even when value is 0")
+	}
+	if *temperature != 0 {
+		t.Errorf("Temperature = %v, want 0", *temperature)
+	}
+}
+
+// TestResolveSampling_OverrideAppliedOnSupportedModel verifies that per-call
+// overrides take precedence over conversation defaults on supported models.
+func TestResolveSampling_OverrideAppliedOnSupportedModel(t *testing.T) {
+	settings := &SampleSettings{
+		Model:       "claude-sonnet-4-6",
+		Temperature: 0.2,
+		TopP:        0.5,
+		TopK:        10,
+	}
+	override := llmapi.Sampling{Temperature: 0.7, TopP: 0.9, TopK: 50}
+
+	temperature, topP, topK := resolveSampling(settings, override)
+	if temperature == nil || *temperature != 0.7 {
+		t.Errorf("Temperature = %v, want 0.7", temperature)
+	}
+	if topP != 0.9 {
+		t.Errorf("TopP = %v, want 0.9", topP)
+	}
+	if topK != 50 {
+		t.Errorf("TopK = %v, want 50", topK)
+	}
+}
+
+// TestResolveSampling_DefaultUsedWhenOverrideZero matches the existing
+// "non-zero override wins" convention: a zero in llmapi.Sampling means
+// "use the conversation's configured value."
+func TestResolveSampling_DefaultUsedWhenOverrideZero(t *testing.T) {
+	settings := &SampleSettings{
+		Model:       "claude-sonnet-4-6",
+		Temperature: 0.4,
+		TopP:        0.6,
+		TopK:        30,
+	}
+	temperature, topP, topK := resolveSampling(settings, llmapi.Sampling{})
+
+	if temperature == nil || *temperature != 0.4 {
+		t.Errorf("Temperature = %v, want 0.4 from settings", temperature)
+	}
+	if topP != 0.6 {
+		t.Errorf("TopP = %v, want 0.6 from settings", topP)
+	}
+	if topK != 30 {
+		t.Errorf("TopK = %v, want 30 from settings", topK)
+	}
+}
+
+// TestResolveSampling_UnrecognizedModelOmitsAll documents that the
+// conservative default (unrecognized model → no sampling params) is what
+// callers actually see. A 400 from a real future model is a worse failure
+// than dropping a sampling param for an unknown ID.
+func TestResolveSampling_UnrecognizedModelOmitsAll(t *testing.T) {
+	settings := &SampleSettings{
+		Model:       "some-other-vendor-model",
+		Temperature: 0.5,
+		TopP:        0.9,
+		TopK:        40,
+	}
+	temperature, topP, topK := resolveSampling(settings, llmapi.Sampling{})
+
+	if temperature != nil {
+		t.Errorf("Temperature should be nil for unrecognized model, got %v", *temperature)
+	}
+	if topP != 0 {
+		t.Errorf("TopP should be 0 for unrecognized model, got %v", topP)
+	}
+	if topK != 0 {
+		t.Errorf("TopK should be 0 for unrecognized model, got %v", topK)
+	}
+}

--- a/sampling_gate_test.go
+++ b/sampling_gate_test.go
@@ -1,0 +1,295 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wbrown/llmapi"
+)
+
+// These tests verify the wire-level outcome of the sampling deprecation gate:
+// for each of the three send paths (sendInternal via Send, SendStreaming, and
+// SendRichStreaming), the JSON body sent to Anthropic must omit temperature,
+// top_p, and top_k for Opus 4.7+ models, and include temperature for older
+// models. The presence-based 400 from the real API can't be exercised in
+// tests, so we capture the body that would have been sent and inspect it.
+
+// stubMessagesServer returns an httptest.Server that captures the request body
+// into *captured and responds with a minimal valid non-streaming message.
+func stubMessagesServer(t *testing.T, captured *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("server: read body: %v", err)
+		}
+		*captured = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "msg_test",
+			"type": "message",
+			"role": "assistant",
+			"model": "test",
+			"content": [{"type": "text", "text": "ok"}],
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 1, "output_tokens": 1}
+		}`))
+	}))
+}
+
+// stubStreamingServer returns an httptest.Server that captures the request
+// body and responds with a minimal valid SSE stream.
+func stubStreamingServer(t *testing.T, captured *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("server: read body: %v", err)
+		}
+		*captured = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("server: response writer does not support flushing")
+		}
+		sse := `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+		_, _ = w.Write([]byte(sse))
+		flusher.Flush()
+	}))
+}
+
+// assertSamplingFieldsAbsent inspects the captured request body and fails the
+// test if any of temperature/top_p/top_k appear as JSON keys at the top level.
+func assertSamplingFieldsAbsent(t *testing.T, body []byte, context string) {
+	t.Helper()
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("%s: unmarshal request body: %v\nbody=%s", context, err, string(body))
+	}
+	for _, key := range []string{"temperature", "top_p", "top_k"} {
+		if _, present := decoded[key]; present {
+			t.Errorf("%s: request body must not contain %q (Opus 4.7+ rejects it); body=%s",
+				context, key, string(body))
+		}
+	}
+}
+
+// assertTemperaturePresent asserts the request body included a temperature
+// field with the expected value.
+func assertTemperaturePresent(t *testing.T, body []byte, want float64, context string) {
+	t.Helper()
+	var decoded struct {
+		Temperature *float64 `json:"temperature"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("%s: unmarshal request body: %v\nbody=%s", context, err, string(body))
+	}
+	if decoded.Temperature == nil {
+		t.Fatalf("%s: temperature must be present on supported model; body=%s", context, string(body))
+	}
+	if *decoded.Temperature != want {
+		t.Errorf("%s: temperature = %v, want %v", context, *decoded.Temperature, want)
+	}
+}
+
+// TestSendInternal_GatesSamplingByModel exercises the sendInternal path
+// (reached via Conversation.Send) for both deprecated and supported models.
+func TestSendInternal_GatesSamplingByModel(t *testing.T) {
+	t.Run("opus-4-8 omits all three", func(t *testing.T) {
+		var captured []byte
+		server := stubMessagesServer(t, &captured)
+		defer server.Close()
+
+		conv := NewConversation("sys")
+		conv.ApiToken = "test-token"
+		conv.SetEndpoint(server.URL)
+		conv.Settings.Model = "claude-opus-4-8"
+		conv.Settings.Temperature = 0.7
+		conv.Settings.TopP = 0.9
+		conv.Settings.TopK = 40
+
+		if _, _, _, _, _, _, err := conv.Send("hello", llmapi.Sampling{}); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		assertSamplingFieldsAbsent(t, captured, "opus-4-8 Send")
+	})
+
+	t.Run("opus-4-7 omits all three", func(t *testing.T) {
+		var captured []byte
+		server := stubMessagesServer(t, &captured)
+		defer server.Close()
+
+		conv := NewConversation("sys")
+		conv.ApiToken = "test-token"
+		conv.SetEndpoint(server.URL)
+		conv.Settings.Model = "claude-opus-4-7"
+		conv.Settings.Temperature = 0.7
+
+		if _, _, _, _, _, _, err := conv.Send("hello", llmapi.Sampling{}); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		assertSamplingFieldsAbsent(t, captured, "opus-4-7 Send")
+	})
+
+	t.Run("sonnet-4-6 includes temperature", func(t *testing.T) {
+		var captured []byte
+		server := stubMessagesServer(t, &captured)
+		defer server.Close()
+
+		conv := NewConversation("sys")
+		conv.ApiToken = "test-token"
+		conv.SetEndpoint(server.URL)
+		conv.Settings.Model = "claude-sonnet-4-6"
+		conv.Settings.Temperature = 0.4
+
+		if _, _, _, _, _, _, err := conv.Send("hello", llmapi.Sampling{}); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		assertTemperaturePresent(t, captured, 0.4, "sonnet-4-6 Send")
+	})
+
+	// The whole reason Temperature is *float64: an explicit 0 on a supported
+	// model must still be sent (greedy decoding), not silently dropped by an
+	// over-eager omitempty.
+	t.Run("sonnet-4-6 sends explicit zero temperature", func(t *testing.T) {
+		var captured []byte
+		server := stubMessagesServer(t, &captured)
+		defer server.Close()
+
+		conv := NewConversation("sys")
+		conv.ApiToken = "test-token"
+		conv.SetEndpoint(server.URL)
+		conv.Settings.Model = "claude-sonnet-4-6"
+		conv.Settings.Temperature = 0.0
+
+		if _, _, _, _, _, _, err := conv.Send("hello", llmapi.Sampling{}); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		assertTemperaturePresent(t, captured, 0.0, "sonnet-4-6 Send T=0")
+	})
+
+	// Override on a 4.7+ model must also be dropped (silently, per design).
+	t.Run("opus-4-8 ignores per-call Sampling override", func(t *testing.T) {
+		var captured []byte
+		server := stubMessagesServer(t, &captured)
+		defer server.Close()
+
+		conv := NewConversation("sys")
+		conv.ApiToken = "test-token"
+		conv.SetEndpoint(server.URL)
+		conv.Settings.Model = "claude-opus-4-8"
+
+		_, _, _, _, _, _, err := conv.Send("hello",
+			llmapi.Sampling{Temperature: 0.9, TopP: 0.95, TopK: 100})
+		if err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		assertSamplingFieldsAbsent(t, captured, "opus-4-8 Send with override")
+	})
+}
+
+// TestSendStreaming_GatesSamplingByModel exercises the SendStreaming path.
+func TestSendStreaming_GatesSamplingByModel(t *testing.T) {
+	t.Run("opus-4-8 omits all three", func(t *testing.T) {
+		var captured []byte
+		server := stubStreamingServer(t, &captured)
+		defer server.Close()
+
+		conv := NewConversation("sys")
+		conv.ApiToken = "test-token"
+		conv.SetEndpoint(server.URL)
+		conv.Settings.Model = "claude-opus-4-8"
+		conv.Settings.Temperature = 0.7
+		conv.Settings.TopP = 0.9
+		conv.Settings.TopK = 40
+
+		if _, _, _, _, _, _, err := conv.SendStreaming("hello", llmapi.Sampling{}, nil); err != nil {
+			t.Fatalf("SendStreaming: %v", err)
+		}
+		assertSamplingFieldsAbsent(t, captured, "opus-4-8 SendStreaming")
+		// Stream flag must still be set on streaming requests.
+		if !strings.Contains(string(captured), `"stream":true`) {
+			t.Errorf("expected stream=true in body; body=%s", string(captured))
+		}
+	})
+
+	t.Run("sonnet-4-6 includes temperature", func(t *testing.T) {
+		var captured []byte
+		server := stubStreamingServer(t, &captured)
+		defer server.Close()
+
+		conv := NewConversation("sys")
+		conv.ApiToken = "test-token"
+		conv.SetEndpoint(server.URL)
+		conv.Settings.Model = "claude-sonnet-4-6"
+		conv.Settings.Temperature = 0.4
+
+		if _, _, _, _, _, _, err := conv.SendStreaming("hello", llmapi.Sampling{}, nil); err != nil {
+			t.Fatalf("SendStreaming: %v", err)
+		}
+		assertTemperaturePresent(t, captured, 0.4, "sonnet-4-6 SendStreaming")
+	})
+}
+
+// TestSendRichStreaming_GatesSamplingByModel exercises the SendRichStreaming
+// path, which has its own local copy of the sampling-resolution block.
+func TestSendRichStreaming_GatesSamplingByModel(t *testing.T) {
+	t.Run("opus-4-8 omits all three", func(t *testing.T) {
+		var captured []byte
+		server := stubStreamingServer(t, &captured)
+		defer server.Close()
+
+		conv := NewConversation("sys")
+		conv.ApiToken = "test-token"
+		conv.SetEndpoint(server.URL)
+		conv.Settings.Model = "claude-opus-4-8"
+		conv.Settings.Temperature = 0.7
+		conv.Settings.TopP = 0.9
+		conv.Settings.TopK = 40
+
+		content := []llmapi.ContentBlock{llmapi.NewTextBlock("hello")}
+		if _, err := conv.SendRichStreaming(content, llmapi.Sampling{}, nil); err != nil {
+			t.Fatalf("SendRichStreaming: %v", err)
+		}
+		assertSamplingFieldsAbsent(t, captured, "opus-4-8 SendRichStreaming")
+	})
+
+	t.Run("sonnet-4-6 includes temperature", func(t *testing.T) {
+		var captured []byte
+		server := stubStreamingServer(t, &captured)
+		defer server.Close()
+
+		conv := NewConversation("sys")
+		conv.ApiToken = "test-token"
+		conv.SetEndpoint(server.URL)
+		conv.Settings.Model = "claude-sonnet-4-6"
+		conv.Settings.Temperature = 0.4
+
+		content := []llmapi.ContentBlock{llmapi.NewTextBlock("hello")}
+		if _, err := conv.SendRichStreaming(content, llmapi.Sampling{}, nil); err != nil {
+			t.Fatalf("SendRichStreaming: %v", err)
+		}
+		assertTemperaturePresent(t, captured, 0.4, "sonnet-4-6 SendRichStreaming")
+	})
+}


### PR DESCRIPTION
## Summary

Claude Opus 4.7 (and 4.8) reject any `temperature`, `top_p`, or `top_k` key in the request body with HTTP 400. The check is **presence-based, not value-based** — even `{"temperature": 0}` fails. This PR adds a model-version-aware gate so the library omits these fields entirely for affected models while keeping them on older models.

Reference: [What's new in Claude Opus 4.7 / 4.8](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7) — *"Setting temperature, top_p, or top_k to a non-default value returns a 400 error on Claude Opus 4.8, same as on Claude Opus 4.7."*

## What changed

`supportsSampling(model)` parses the Anthropic model ID and reports whether the model accepts the three sampling parameters. The cutoff is family-agnostic: anything at version `4.7` or newer omits them. Recognized forms include `claude-<family>-<major>-<minor>[-date]`, the legacy `claude-3-5-sonnet-...` shape, and dotted `claude-2.1` / `claude-instant-1.2`. Unrecognized model IDs report `false` — a 400 from a real future model is a worse failure than dropping a sampling param for an unknown one.

`Messages.Temperature` is now `*float64` with `omitempty`. `float64` + `omitempty` would have incorrectly dropped intentional `T=0` (greedy decoding) on supported models, so a pointer is needed to distinguish "not set" from "explicitly zero." `TopP` and `TopK` stay value-typed; their existing `omitempty` + zero-as-unset semantics work correctly because `top_p=0` and `top_k=0` have no meaningful value to preserve.

`resolveSampling` centralizes the gate so all three send paths (`sendInternal`, `SendRichStreaming`, `SendStreaming`) share one decision point instead of triplicating the override-resolution block.

## Tests

- `model_version_test.go` — parser, gate, and resolver unit coverage across all known model-ID shapes (modern, legacy, dotted, unknown).
- `sampling_gate_test.go` — wire-level tests that capture the actual outbound request JSON for each of the three send paths and assert: all three fields are **absent** for `claude-opus-4-7` / `claude-opus-4-8`, present on `claude-sonnet-4-6`, and that an explicit `T=0` on a supported model is still sent (this is the case that justifies the pointer change).

Full suite (including live-API integration tests): 370s, all green.

## Breaking change

`Messages.Temperature`: `float64` → `*float64`.

The only consumer of the request-payload `Messages` struct directly is internal to this package. `SampleSettings.Temperature` (the public API used by callers) is unchanged. The `llmapi.Conversation` interface contract is unchanged (the compile-time check `var _ llmapi.Conversation = (*Conversation)(nil)` at `api.go:20` still holds). External code that constructed `anthropic.Messages{Temperature: 0.5}` directly would need to switch to `Temperature: ptrTo(0.5)`, but configuring via `Settings.Temperature` (a `float64`) is unaffected.
