### PR TITLE
Fix empty-text send: deliver pending/tool_result turn, reject open tool_use

### DIFF
--- a/api.go
+++ b/api.go
@@ -327,6 +327,20 @@ func NewConversation(system string) *Conversation {
 	return &conversation
 }
 
+// hasToolUseBlock reports whether the message contains a tool_use block — an open tool call
+// awaiting the client's tool_result. Such a turn cannot be continued with an empty-text send.
+func hasToolUseBlock(m *Message) bool {
+	if m == nil || m.Content == nil {
+		return false
+	}
+	for _, block := range *m.Content {
+		if block.ContentType == "tool_use" {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Conversation) sendInternal(text string, sampling llmapi.Sampling) (*Response, error) {
 	if c.Settings == nil {
 		return nil, fmt.Errorf("conversation settings not set")
@@ -336,28 +350,22 @@ func (c *Conversation) sendInternal(text string, sampling llmapi.Sampling) (*Res
 	}
 	if text != "" {
 		c.AddMessage(llmapi.RoleUser, text)
-	} else if len(*c.Messages) > 2 &&
-		(*c.Messages)[len(*c.Messages)-1].Role !=
-			"assistant" {
-		// Check if the last user message contains tool results
-		lastMsg := (*c.Messages)[len(*c.Messages)-1]
-		if lastMsg.Role == "user" && lastMsg.Content != nil && len(*lastMsg.Content) > 0 {
-			// Check if this is a tool result message
-			hasToolResult := false
-			for _, block := range *lastMsg.Content {
-				if block.ContentType == "tool_result" {
-					hasToolResult = true
-					break
-				}
-			}
-			if !hasToolResult {
-				// If the text is empty, and the last message is not from the
-				// assistant, we can't continue the conversation, so return
+	} else if n := len(*c.Messages); n > 0 {
+		// Empty text means "send the conversation as it stands." Validate the trailing turn:
+		//   - assistant turn → continue (prefill), UNLESS it is an open tool_use request
+		//     (awaiting the client's tool_result); that can't be continued → reject, at any length.
+		//   - user turn with content (plain text or a tool_result) → respond → send, but only past
+		//     the opening exchange (the > 2 gate; the first user turn is a valid initial send).
+		//   - a user turn with no content (or any other trailing turn) → nothing to answer → reject.
+		lastMsg := (*c.Messages)[n-1]
+		if lastMsg.Role == "assistant" {
+			if hasToolUseBlock(lastMsg) {
 				return nil, fmt.Errorf("cannot continue conversation")
 			}
-			// If it's a tool result, allow continuation
-		} else {
-			return nil, fmt.Errorf("cannot continue conversation")
+		} else if n > 2 {
+			if !(lastMsg.Role == "user" && lastMsg.Content != nil && len(*lastMsg.Content) > 0) {
+				return nil, fmt.Errorf("cannot continue conversation")
+			}
 		}
 	}
 
@@ -830,22 +838,19 @@ func (conversation *Conversation) SendStreaming(text string, sampling llmapi.Sam
 	// Add user message if provided
 	if text != "" {
 		conversation.AddMessage(llmapi.RoleUser, text)
-	} else if len(*conversation.Messages) > 0 &&
-		(*conversation.Messages)[len(*conversation.Messages)-1].Role != "assistant" {
-		// Check if the last user message contains tool results
-		lastMsg := (*conversation.Messages)[len(*conversation.Messages)-1]
-		if lastMsg.Role == "user" && lastMsg.Content != nil && len(*lastMsg.Content) > 0 {
-			hasToolResult := false
-			for _, block := range *lastMsg.Content {
-				if block.ContentType == "tool_result" {
-					hasToolResult = true
-					break
-				}
-			}
-			if !hasToolResult {
+	} else if n := len(*conversation.Messages); n > 0 {
+		// Empty text means "send the conversation as it stands." Validate the trailing turn:
+		//   - assistant turn → continue (prefill), UNLESS it is an open tool_use request
+		//     (awaiting the client's tool_result); that can't be continued → reject.
+		//   - user turn with content → respond → send. Content may be plain text (e.g. a turn
+		//     left queued by a failed send and now retried) or a tool_result; the API accepts either.
+		//   - a user turn with no content (or any other trailing turn) → nothing to answer → reject.
+		lastMsg := (*conversation.Messages)[n-1]
+		if lastMsg.Role == "assistant" {
+			if hasToolUseBlock(lastMsg) {
 				return "", "", 0, 0, 0, 0, fmt.Errorf("cannot continue conversation")
 			}
-		} else {
+		} else if !(lastMsg.Role == "user" && lastMsg.Content != nil && len(*lastMsg.Content) > 0) {
 			return "", "", 0, 0, 0, 0, fmt.Errorf("cannot continue conversation")
 		}
 	}

--- a/empty_text_send_test.go
+++ b/empty_text_send_test.go
@@ -1,0 +1,249 @@
+package anthropic
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/wbrown/llmapi"
+)
+
+// TestSendStreaming_EmptyText_SendsPendingUserTurn pins the fix: an empty-text SendStreaming
+// whose conversation ends in a plain user turn (no tool_result) must SEND it as-is — the
+// pending request — not reject it with "cannot continue conversation". This is the retry
+// path: a failed send leaves the user turn queued, and the retry re-sends it via empty text.
+//
+// The guard runs before any network I/O, so a pre-cancelled context keeps this offline and
+// deterministic: past the guard the request fails fast at the transport, and the only thing
+// asserted is that the failure is NOT the guard's "cannot continue conversation".
+//
+// Before the fix this returns "cannot continue conversation" (api.go ~846) and the test fails.
+func TestSendStreaming_EmptyText_SendsPendingUserTurn(t *testing.T) {
+	orig := retryDelay
+	retryDelay = 0
+	defer func() { retryDelay = orig }()
+
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddMessage(llmapi.RoleUser, "where does this take place?") // pending plain-user turn
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conv.SetContext(ctx)
+
+	_, _, _, _, _, _, err := conv.SendStreaming("", llmapi.Sampling{}, nil)
+	if err == nil {
+		t.Fatal("expected a transport error from the cancelled request")
+	}
+	if strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("empty-text send of a pending user turn was rejected by the guard: %v", err)
+	}
+}
+
+// TestSendStreaming_EmptyText_RejectsEmptyTrailingTurn pins that the guard is PRESERVED for a
+// trailing user turn with no content — there is nothing the model can answer, so
+// "cannot continue conversation" is still returned. The fix must not flatten this away.
+func TestSendStreaming_EmptyText_RejectsEmptyTrailingTurn(t *testing.T) {
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddRichMessage(llmapi.RoleUser, nil) // user turn with no content blocks
+
+	_, _, _, _, _, _, err := conv.SendStreaming("", llmapi.Sampling{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("expected 'cannot continue conversation' for an empty trailing user turn, got: %v", err)
+	}
+}
+
+// TestSendStreaming_EmptyText_AllowsToolResultTurn pins that the tool_result continuation path
+// is PRESERVED: a trailing user turn carrying a tool_result is sent as-is (it can only be
+// delivered via AddRichMessage + empty-text send), not rejected. narrative-generators doesn't
+// exercise tools, so this guards the library contract directly.
+func TestSendStreaming_EmptyText_AllowsToolResultTurn(t *testing.T) {
+	orig := retryDelay
+	retryDelay = 0
+	defer func() { retryDelay = orig }()
+
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddRichMessage(llmapi.RoleUser, []llmapi.ContentBlock{
+		llmapi.NewToolResultBlock("tool-123", "result data", false),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conv.SetContext(ctx)
+
+	_, _, _, _, _, _, err := conv.SendStreaming("", llmapi.Sampling{}, nil)
+	if err == nil {
+		t.Fatal("expected a transport error from the cancelled request")
+	}
+	if strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("tool_result continuation was rejected by the guard: %v", err)
+	}
+}
+
+// The non-streaming Send path (sendInternal) has the same empty-text guard, with a > 2 message
+// threshold, so these mirror the SendStreaming cases on a multi-turn history where the guard
+// actually applies.
+
+func TestSendInternal_EmptyText_SendsPendingUserTurn(t *testing.T) {
+	orig := retryDelay
+	retryDelay = 0
+	defer func() { retryDelay = orig }()
+
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddMessage(llmapi.RoleUser, "q1")
+	conv.AddMessage(llmapi.RoleAssistant, "a1")
+	conv.AddMessage(llmapi.RoleUser, "q2") // trailing plain-user turn, len 3 > 2
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conv.SetContext(ctx)
+
+	if _, err := conv.sendInternal("", llmapi.Sampling{}); err == nil {
+		t.Fatal("expected a transport error from the cancelled request")
+	} else if strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("empty-text send of a pending user turn was rejected by the guard: %v", err)
+	}
+}
+
+func TestSendInternal_EmptyText_RejectsEmptyTrailingTurn(t *testing.T) {
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddMessage(llmapi.RoleUser, "q1")
+	conv.AddMessage(llmapi.RoleAssistant, "a1")
+	conv.AddRichMessage(llmapi.RoleUser, nil) // trailing user turn with no content, len 3 > 2
+
+	_, err := conv.sendInternal("", llmapi.Sampling{})
+	if err == nil || !strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("expected 'cannot continue conversation' for an empty trailing user turn, got: %v", err)
+	}
+}
+
+func TestSendInternal_EmptyText_AllowsToolResultTurn(t *testing.T) {
+	orig := retryDelay
+	retryDelay = 0
+	defer func() { retryDelay = orig }()
+
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddMessage(llmapi.RoleUser, "q1")
+	conv.AddMessage(llmapi.RoleAssistant, "a1")
+	conv.AddRichMessage(llmapi.RoleUser, []llmapi.ContentBlock{
+		llmapi.NewToolResultBlock("tool-123", "result data", false),
+	}) // trailing tool_result turn, len 3 > 2
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conv.SetContext(ctx)
+
+	if _, err := conv.sendInternal("", llmapi.Sampling{}); err == nil {
+		t.Fatal("expected a transport error from the cancelled request")
+	} else if strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("tool_result continuation was rejected by the guard: %v", err)
+	}
+}
+
+// appendAssistantToolUse adds an assistant turn that contains a tool_use block — an open tool
+// call awaiting the client's tool_result. Built directly (white-box) because the guard keys on
+// the block's ContentType, which is what a real tool_use turn carries.
+func appendAssistantToolUse(conv *Conversation) {
+	*conv.Messages = append(*conv.Messages, &Message{
+		Role:    "assistant",
+		Content: &[]ContentBlock{{ContentType: "tool_use"}},
+	})
+}
+
+// TestSendStreaming_EmptyText_RejectsOpenToolUseRequest pins the request-side fix: an empty-text
+// send when the trailing turn is an assistant tool_use REQUEST must be rejected — the model is
+// awaiting the client's tool_result and cannot produce output. (You add the tool_result, a user
+// turn, and *then* send.)
+func TestSendStreaming_EmptyText_RejectsOpenToolUseRequest(t *testing.T) {
+	orig := retryDelay
+	retryDelay = 0
+	defer func() { retryDelay = orig }()
+
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddMessage(llmapi.RoleUser, "weather?")
+	appendAssistantToolUse(conv) // open tool_use request, no tool_result yet
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conv.SetContext(ctx)
+
+	_, _, _, _, _, _, err := conv.SendStreaming("", llmapi.Sampling{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("expected 'cannot continue conversation' for empty text after an open tool_use request, got: %v", err)
+	}
+}
+
+// TestSendStreaming_EmptyText_ContinuesAfterAssistantResponse pins that the request-side check
+// does NOT break the legitimate continuation: empty text after a finished/cut-off assistant turn
+// (no tool_use) must still proceed (prefill/continue), not be rejected.
+func TestSendStreaming_EmptyText_ContinuesAfterAssistantResponse(t *testing.T) {
+	orig := retryDelay
+	retryDelay = 0
+	defer func() { retryDelay = orig }()
+
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddMessage(llmapi.RoleUser, "hi")
+	conv.AddMessage(llmapi.RoleAssistant, "hello") // a normal assistant turn
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conv.SetContext(ctx)
+
+	if _, _, _, _, _, _, err := conv.SendStreaming("", llmapi.Sampling{}, nil); err == nil {
+		t.Fatal("expected a transport error from the cancelled request")
+	} else if strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("empty text after a normal assistant turn must continue, not be rejected: %v", err)
+	}
+}
+
+// TestSendInternal_EmptyText_RejectsOpenToolUseRequest mirrors the request-side fix for Send, and
+// pins that it fires at len 2 — below the > 2 user-side gate — because an open tool_use request
+// is invalid regardless of conversation length.
+func TestSendInternal_EmptyText_RejectsOpenToolUseRequest(t *testing.T) {
+	orig := retryDelay
+	retryDelay = 0
+	defer func() { retryDelay = orig }()
+
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddMessage(llmapi.RoleUser, "weather?")
+	appendAssistantToolUse(conv) // len 2: open tool_use request
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conv.SetContext(ctx)
+
+	if _, err := conv.sendInternal("", llmapi.Sampling{}); err == nil || !strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("expected 'cannot continue conversation' for empty text after an open tool_use request, got: %v", err)
+	}
+}
+
+// TestSendInternal_EmptyText_ContinuesAfterAssistantResponse pins that a normal trailing assistant
+// turn still continues under Send (no tool_use → proceed).
+func TestSendInternal_EmptyText_ContinuesAfterAssistantResponse(t *testing.T) {
+	orig := retryDelay
+	retryDelay = 0
+	defer func() { retryDelay = orig }()
+
+	conv := NewConversation("system")
+	conv.ApiToken = "dummy"
+	conv.AddMessage(llmapi.RoleUser, "hi")
+	conv.AddMessage(llmapi.RoleAssistant, "hello") // len 2, trailing assistant turn
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conv.SetContext(ctx)
+
+	if _, err := conv.sendInternal("", llmapi.Sampling{}); err == nil {
+		t.Fatal("expected a transport error from the cancelled request")
+	} else if strings.Contains(err.Error(), "cannot continue conversation") {
+		t.Fatalf("empty text after a normal assistant turn must continue, not be rejected: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

An empty-text `Send` / `SendStreaming` means "respond to the conversation as it stands." The retry path depends on this: a failed send leaves the pending user turn queued on the conversation, and the retry re-sends it with empty text rather than re-appending the prompt.

The previous guard rejected that case. When the trailing turn was a plain user turn *without* a `tool_result` block, it returned `cannot continue conversation`. So once a send failed, the queued user turn could never be delivered — every retry hit the same rejection and the conversation was permanently poisoned. This surfaced when a long-running streaming session stalled: the caller's retry fired with empty text, and the recovery attempt was rejected instead of re-sending the pending turn.

## Fix

Restructure the empty-text guard in both `sendInternal` and `SendStreaming` around the trailing turn:

- **assistant turn** → continue (prefill), *unless* it is an open `tool_use` request awaiting the client's `tool_result`; that can't be continued with an empty send, so it is rejected at any conversation length (new request-side check).
- **user turn with content** (plain text *or* a `tool_result`) → send. The content may be a turn left queued by a failed send and now retried, or a real tool_result — the API accepts either. `sendInternal` keeps its `> 2` gate so the opening exchange isn't short-circuited.
- **user turn with no content** (or any other trailing turn) → nothing to answer → reject.

The distinction the old code conflated is request-side vs. response-side `tool_use`: an assistant `tool_use` *request* (no `tool_result` yet) must be rejected, while a plain pending user turn must be *sent*, not rejected. `hasToolUseBlock` is added to detect the open-request case.

## Tests

`empty_text_send_test.go` covers both code paths (`Send` and `SendStreaming`):

- pending plain-user turn is sent, not rejected
- `tool_result` continuation is sent
- empty trailing user turn (no content) is rejected
- open `tool_use` request is rejected
- normal post-assistant continuation still proceeds

They run offline — pre-cancelled context with `retryDelay = 0`, so the guard (which runs before any network I/O) is the only thing under test: each asserts whether the guard fired, not transport behavior.