### PR TITLE
Reasoning: ReasoningEffort -> extended-thinking budget + tagged stream deltas

### DIFF
--- a/api.go
+++ b/api.go
@@ -227,14 +227,39 @@ type SampleSettings struct {
 	TopP float64 `json:"top_p,omitempty"`
 	// TopK limits sampling to the top K tokens.
 	TopK int `json:"top_k,omitempty"`
-	// Thinking configuration for extended reasoning
-	Thinking *ThinkingConfig `json:"thinking,omitempty"`
 }
 
 // ThinkingConfig configures extended thinking for Claude
 type ThinkingConfig struct {
 	Type         string `json:"type"`          // "enabled"
 	BudgetTokens int    `json:"budget_tokens"` // minimum 1024
+}
+
+// thinkingForEffort maps a requested reasoning effort to Claude's extended-thinking
+// config. ReasoningOff returns nil (no extended thinking); low is the 1024 floor,
+// and medium/high/max scale the budget to 1/4, 1/2, 3/4 of maxTokens. The budget
+// must stay under maxTokens, so a maxTokens too small to fit a >=1024 budget under
+// max_tokens is an error.
+func thinkingForEffort(effort llmapi.ReasoningEffort, maxTokens int) (*ThinkingConfig, error) {
+	if effort == llmapi.ReasoningOff {
+		return nil, nil
+	}
+	budget := 1024
+	switch effort {
+	case llmapi.ReasoningMedium:
+		budget = maxTokens / 4
+	case llmapi.ReasoningHigh:
+		budget = maxTokens / 2
+	case llmapi.ReasoningMax:
+		budget = maxTokens * 3 / 4
+	}
+	if budget < 1024 {
+		budget = 1024
+	}
+	if budget >= maxTokens {
+		return nil, fmt.Errorf("reasoning effort %s needs max_tokens > %d to fit a thinking budget under max_tokens, got max_tokens=%d", effort, budget, maxTokens)
+	}
+	return &ThinkingConfig{Type: "enabled", BudgetTokens: budget}, nil
 }
 
 // A Conversation is a sequence of messages between a user and an assistant.
@@ -395,6 +420,11 @@ func (c *Conversation) sendInternal(text string, sampling llmapi.Sampling) (*Res
 	// (Claude Opus 4.7+; see supportsSampling).
 	temperature, topP, topK := resolveSampling(c.Settings, sampling)
 
+	thinkingCfg, thinkErr := thinkingForEffort(sampling.ReasoningEffort, c.Settings.MaxTokens)
+	if thinkErr != nil {
+		return nil, thinkErr
+	}
+
 	// Apply conversation turn cache breakpoints before building the request
 	c.applyCacheBreakpoints()
 
@@ -407,7 +437,7 @@ func (c *Conversation) sendInternal(text string, sampling llmapi.Sampling) (*Res
 		System:      system,
 		Messages:    c.Messages,
 		Tools:       tools,
-		Thinking:    c.Settings.Thinking,
+		Thinking:    thinkingCfg,
 	}
 
 	// Marshal messages to JSON
@@ -568,6 +598,11 @@ func (c *Conversation) SendRichStreaming(content []llmapi.ContentBlock, sampling
 	// Resolve sampling parameters, gated by model capability (Opus 4.7+ omits them).
 	temperature, topP, topK := resolveSampling(c.Settings, sampling)
 
+	thinkingCfg, thinkErr := thinkingForEffort(sampling.ReasoningEffort, c.Settings.MaxTokens)
+	if thinkErr != nil {
+		return nil, thinkErr
+	}
+
 	// Apply conversation turn cache breakpoints before building the request
 	c.applyCacheBreakpoints()
 
@@ -580,7 +615,7 @@ func (c *Conversation) SendRichStreaming(content []llmapi.ContentBlock, sampling
 		System:      system,
 		Messages:    c.Messages,
 		Tools:       c.Tools,
-		Thinking:    c.Settings.Thinking,
+		Thinking:    thinkingCfg,
 		Stream:      true,
 	}
 
@@ -872,6 +907,11 @@ func (conversation *Conversation) SendStreaming(text string, sampling llmapi.Sam
 	// Resolve sampling parameters, gated by model capability (Opus 4.7+ omits them).
 	temperature, topP, topK := resolveSampling(conversation.Settings, sampling)
 
+	thinkingCfg, thinkErr := thinkingForEffort(sampling.ReasoningEffort, conversation.Settings.MaxTokens)
+	if thinkErr != nil {
+		return "", "", 0, 0, 0, 0, thinkErr
+	}
+
 	// Apply conversation turn cache breakpoints before building the request
 	conversation.applyCacheBreakpoints()
 
@@ -884,7 +924,7 @@ func (conversation *Conversation) SendStreaming(text string, sampling llmapi.Sam
 		System:      system,
 		Messages:    conversation.Messages,
 		Tools:       conversation.Tools,
-		Thinking:    conversation.Settings.Thinking,
+		Thinking:    thinkingCfg,
 		Stream:      true,
 	}
 
@@ -1055,13 +1095,14 @@ func (conversation *Conversation) parseSSEStreamRich(body io.Reader, callback ll
 				case "text_delta":
 					textBuilder.WriteString(event.Delta.Text)
 					if callback != nil {
-						callback(event.Delta.Text, false)
+						callback(llmapi.StreamDelta{Text: event.Delta.Text, Kind: llmapi.TokenContent})
 					}
 				case "thinking_delta":
 					thinkingBuilder.WriteString(event.Delta.Thinking)
-					// Optionally stream thinking to callback too
+					// Stream thinking to the callback tagged as reasoning so consumers
+					// can route it separately from content.
 					if callback != nil && event.Delta.Thinking != "" {
-						callback(event.Delta.Thinking, false)
+						callback(llmapi.StreamDelta{Text: event.Delta.Thinking, Kind: llmapi.TokenReasoning})
 					}
 				}
 			}
@@ -1082,7 +1123,7 @@ func (conversation *Conversation) parseSSEStreamRich(body io.Reader, callback ll
 		case "message_stop":
 			// Stream complete - signal done to callback
 			if callback != nil {
-				callback("", true)
+				callback(llmapi.StreamDelta{Done: true})
 			}
 		}
 	}
@@ -1238,8 +1279,8 @@ func (conversation *Conversation) GetMessages() []llmapi.Message {
 // This includes all input and output tokens across all Send calls.
 func (conversation *Conversation) GetUsage() llmapi.Usage {
 	return llmapi.Usage{
-		InputTokens:             conversation.Usage.InputTokens,
-		OutputTokens:            conversation.Usage.OutputTokens,
+		InputTokens:              conversation.Usage.InputTokens,
+		OutputTokens:             conversation.Usage.OutputTokens,
 		CacheCreationInputTokens: conversation.CacheStats.TotalCacheCreationTokens,
 		CacheReadInputTokens:     conversation.CacheStats.TotalCacheReadTokens,
 	}
@@ -1430,22 +1471,6 @@ func (c *Conversation) DisableBeta(beta string) {
 	}
 
 	c.Settings.Beta = strings.Join(newBetas, ",")
-}
-
-// EnableThinking enables extended thinking with the specified token budget
-func (c *Conversation) EnableThinking(budgetTokens int) {
-	if c.Settings == nil {
-		settings := DefaultSettings
-		c.Settings = &settings
-	}
-
-	if budgetTokens < 1024 {
-		budgetTokens = 1024 // Minimum required
-	}
-	c.Settings.Thinking = &ThinkingConfig{
-		Type:         "enabled",
-		BudgetTokens: budgetTokens,
-	}
 }
 
 // Model represents an available Claude model

--- a/api_test.go
+++ b/api_test.go
@@ -51,8 +51,8 @@ func TestConversation_SendStreaming(t *testing.T) {
 
 	// Track how many times the callback is invoked with content
 	var tokenCount int
-	callback := func(text string, done bool) {
-		if !done && text != "" {
+	callback := func(d llmapi.StreamDelta) {
+		if !d.Done && d.Text != "" {
 			tokenCount++
 		}
 	}
@@ -118,8 +118,8 @@ func TestConversation_SendStreamingUntilDone(t *testing.T) {
 	conversation.Settings.MaxTokens = 125
 
 	var tokenCount int
-	callback := func(text string, done bool) {
-		if !done && text != "" {
+	callback := func(d llmapi.StreamDelta) {
+		if !d.Done && d.Text != "" {
 			tokenCount++
 		}
 	}
@@ -543,8 +543,8 @@ func TestConversationCaching_StreamingIntegration(t *testing.T) {
 
 	for i, turn := range turns {
 		var tokenCount int
-		callback := func(text string, done bool) {
-			if !done && text != "" {
+		callback := func(d llmapi.StreamDelta) {
+			if !d.Done && d.Text != "" {
 				tokenCount++
 			}
 		}
@@ -904,9 +904,9 @@ data: {"type":"message_stop"}
 	conv := NewConversation("Test")
 	var callbackText string
 	var callbackDone bool
-	callback := func(text string, done bool) {
-		callbackText += text
-		callbackDone = done
+	callback := func(d llmapi.StreamDelta) {
+		callbackText += d.Text
+		callbackDone = d.Done
 	}
 
 	reader := strings.NewReader(sseData)
@@ -1217,8 +1217,8 @@ func TestContextCancellationMidStream(t *testing.T) {
 	var cancelled bool
 
 	// Cancel after receiving some tokens
-	callback := func(text string, done bool) {
-		if done {
+	callback := func(d llmapi.StreamDelta) {
+		if d.Done {
 			return
 		}
 		tokensReceived++

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/wbrown/anthropic
 
 go 1.22.5
 
-require github.com/wbrown/llmapi v0.0.0-20260306155236-40bc5eb4803e
+require github.com/wbrown/llmapi v0.0.0-20260618170904-389836bd98d1

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ github.com/wbrown/llmapi v0.0.0-20260115200758-509a51a62290 h1:L/mjQ72CjoLYLYI/d
 github.com/wbrown/llmapi v0.0.0-20260115200758-509a51a62290/go.mod h1:Xfi3YTGRYZ/OuDWSFDPSW8vmIMgG1P0p4pmlggqOIos=
 github.com/wbrown/llmapi v0.0.0-20260306155236-40bc5eb4803e h1:8YQySL7EkKukeJe8E3cxtmO9XwWfgjElZtrJDvd7QDU=
 github.com/wbrown/llmapi v0.0.0-20260306155236-40bc5eb4803e/go.mod h1:Xfi3YTGRYZ/OuDWSFDPSW8vmIMgG1P0p4pmlggqOIos=
+github.com/wbrown/llmapi v0.0.0-20260618170904-389836bd98d1 h1:iIJcxIr/x8H/CjYTorWqnjPVUZCTogsYfPbTsaLAWsQ=
+github.com/wbrown/llmapi v0.0.0-20260618170904-389836bd98d1/go.mod h1:Xfi3YTGRYZ/OuDWSFDPSW8vmIMgG1P0p4pmlggqOIos=

--- a/reasoning_effort_test.go
+++ b/reasoning_effort_test.go
@@ -1,0 +1,44 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/wbrown/llmapi"
+)
+
+// TestThinkingForEffort pins the reasoning-effort -> extended-thinking-budget
+// mapping: off => no thinking; low => the 1024 floor; medium/high/max => 1/4, 1/2,
+// 3/4 of MaxTokens; and a MaxTokens too small to fit a >=1024 budget under
+// max_tokens is an error (you cannot ask for reasoning with <1024 budget).
+func TestThinkingForEffort(t *testing.T) {
+	if cfg, err := thinkingForEffort(llmapi.ReasoningOff, 8192); err != nil || cfg != nil {
+		t.Errorf("off: got cfg=%v err=%v, want nil,nil", cfg, err)
+	}
+	if cfg, err := thinkingForEffort(llmapi.ReasoningLow, 8192); err != nil || cfg == nil || cfg.Type != "enabled" || cfg.BudgetTokens != 1024 {
+		t.Errorf("low: got %+v err=%v, want enabled/1024", cfg, err)
+	}
+
+	scaled := []struct {
+		effort     llmapi.ReasoningEffort
+		maxTokens  int
+		wantBudget int
+	}{
+		{llmapi.ReasoningMedium, 8192, 2048},
+		{llmapi.ReasoningHigh, 8192, 4096},
+		{llmapi.ReasoningMax, 8192, 6144},
+	}
+	for _, tc := range scaled {
+		cfg, err := thinkingForEffort(tc.effort, tc.maxTokens)
+		if err != nil || cfg == nil || cfg.BudgetTokens != tc.wantBudget {
+			t.Errorf("%v @ max=%d: got %+v err=%v, want budget %d", tc.effort, tc.maxTokens, cfg, err, tc.wantBudget)
+		}
+	}
+
+	// MaxTokens too small to fit a >=1024 budget under max_tokens must error.
+	if _, err := thinkingForEffort(llmapi.ReasoningHigh, 1024); err == nil {
+		t.Error("max_tokens=1024: want error (no room for a >=1024 budget under max_tokens)")
+	}
+	if _, err := thinkingForEffort(llmapi.ReasoningLow, 512); err == nil {
+		t.Error("max_tokens=512: want error")
+	}
+}


### PR DESCRIPTION
## What

`Sampling.ReasoningEffort` is now the single reasoning control, replacing the `EnableThinking` method and the `SampleSettings.Thinking` field (both removed). `thinkingForEffort` maps effort to Claude extended-thinking config:

- `ReasoningOff` -> no extended thinking (nil)
- `ReasoningLow` -> the 1024-token floor
- `ReasoningMedium` / `ReasoningHigh` / `ReasoningMax` -> 1/4, 1/2, 3/4 of `MaxTokens`

The budget must stay under `MaxTokens` (the model needs room to answer after thinking), so a `MaxTokens` too small to fit a >=1024 budget under `max_tokens` returns an error rather than silently clamping. The mapping is wired into `sendInternal`, `SendStreaming`, and `SendRichStreaming`, each propagating that error.

`StreamCallback` now receives `llmapi.StreamDelta`, so each delta carries a `Kind`: `thinking_delta` is tagged `TokenReasoning`, `text_delta` is tagged `TokenContent`, and `message_stop` signals `Done`. Thinking is surfaced for display or recording but, as before, is not part of the returned content.

Requires `llmapi` `v0.0.0-20260618170904-389836bd98d1`, which adds `StreamDelta` / `TokenKind` and the `ReasoningEffort` enum.

## Tests

- `TestThinkingForEffort` pins the effort->budget mapping (off=nil, low=1024 floor, medium/high/max = 1/4, 1/2, 3/4 of MaxTokens) and the error cases where MaxTokens cannot fit a >=1024 budget under max_tokens.
- Existing streaming tests migrated to the `StreamDelta` callback.
- Full suite passes against the published `llmapi` with the workspace disabled (live API).